### PR TITLE
feat: setup ssg

### DIFF
--- a/src/app/(_courses)/[categoryId]/[...slug]/page.tsx
+++ b/src/app/(_courses)/[categoryId]/[...slug]/page.tsx
@@ -30,3 +30,44 @@ export default async function Page({
 
   return <MDXContent />;
 }
+
+export async function generateStaticParams() {
+  const categories = fs.readdirSync(path.join(env.SRC_FOLDER, 'content'));
+
+  const paths: { categoryId: string; slug: string[] }[] = [];
+
+  for (const category of categories) {
+    const categoryPath = path.join(env.SRC_FOLDER, 'content', category);
+
+    // Get all MDX files recursively
+    function getAllMdxFiles(dir: string): string[] {
+      const files: string[] = [];
+      const items = fs.readdirSync(dir);
+
+      for (const item of items) {
+        const fullPath = path.join(dir, item);
+        if (fs.statSync(fullPath).isDirectory()) {
+          files.push(...getAllMdxFiles(fullPath));
+        } else if (item.endsWith('.mdx')) {
+          files.push(fullPath);
+        }
+      }
+      return files;
+    }
+
+    const mdxFiles = getAllMdxFiles(categoryPath);
+
+    // Convert file paths to route parameters
+    for (const file of mdxFiles) {
+      const relativePath = path.relative(categoryPath, file);
+      const slug = relativePath.replace(/\.mdx$/, '').split(path.sep);
+
+      paths.push({
+        categoryId: category,
+        slug: slug
+      });
+    }
+  }
+
+  return paths;
+}

--- a/src/app/(_courses)/[categoryId]/layout.tsx
+++ b/src/app/(_courses)/[categoryId]/layout.tsx
@@ -9,6 +9,12 @@ import React, { PropsWithChildren } from 'react';
 import { CourseNavbar } from './course-nav';
 import { ContentSidebar } from './sidebar';
 
+export function generateStaticParams() {
+  return Object.values(categoriesById).map(category => ({
+    params: { categoryId: category.id }
+  }));
+}
+
 const JSInterviewQuestion = async ({
   children,
   params


### PR DESCRIPTION
This pull request introduces new static generation functions to improve the performance and scalability of the course pages. The most important changes include the addition of the `generateStaticParams` function in two key files.

Static generation improvements:

* `src/app/(_courses)/[categoryId]/[...slug]/page.tsx`: Added the `generateStaticParams` function to generate static paths for course pages by recursively reading MDX files from the content directory. ([src/app/(_courses)/[categoryId]/[...slug]/page.tsxR33-R73](diffhunk://#diff-4c070690a8f6740df28e2e0b3ef15415ff0e0ddae187a19f27069eaa6f894931R33-R73))
* `src/app/(_courses)/[categoryId]/layout.tsx`: Added the `generateStaticParams` function to generate static paths for category layouts using predefined category IDs. ([src/app/(_courses)/[categoryId]/layout.tsxR12-R17](diffhunk://#diff-bb30c42d8ad0576022d8fe4180ea035ea3ca2fa86a3e3ca6dcbe4b5ee2541bc9R12-R17))