### PR TITLE
Fix blogs url miss match

### DIFF
--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -18,7 +18,7 @@ const computedFields = {
 
   slug: {
     type: 'string',
-    resolve: doc => doc._raw.flattenedPath.split('/').slice(1).join('/')
+    resolve: doc => doc._raw.flattenedPath.split('/').join('/')
   },
 
   id: {

--- a/src/app/[categoryId]/[...slug]/page.tsx
+++ b/src/app/[categoryId]/[...slug]/page.tsx
@@ -8,9 +8,13 @@ export default async function Page({
 }: {
   params: Promise<{ slug: string[]; categoryId: string }>;
 }) {
-  const { slug: slugs } = await params;
+  const { slug: slugs, categoryId } = await params;
 
-  const slug = slugs.join('/');
+  const slug = [categoryId, ...slugs].join('/');
+
+  console.log(slug);
+  console.log(slugs);
+  console.log(allBlogs);
 
   const blog = allBlogs.find(blog => blog.slug === slug.replace('.mdx', ''));
 

--- a/src/app/[categoryId]/[...slug]/page.tsx
+++ b/src/app/[categoryId]/[...slug]/page.tsx
@@ -12,10 +12,6 @@ export default async function Page({
 
   const slug = [categoryId, ...slugs].join('/');
 
-  console.log(slug);
-  console.log(slugs);
-  console.log(allBlogs);
-
   const blog = allBlogs.find(blog => blog.slug === slug.replace('.mdx', ''));
 
   if (!blog) notFound();

--- a/src/app/[categoryId]/sidebar.tsx
+++ b/src/app/[categoryId]/sidebar.tsx
@@ -25,7 +25,7 @@ type Props = {
 
 export function ContentSidebar({ menu, hideSidebar = false, children }: Props) {
   return (
-    <div className="container mx-auto flex min-h-svh !w-full divide-x-4">
+    <div className="container mx-auto flex min-h-svh !w-full divide-x-2">
       {hideSidebar ? null : (
         <div className="scrollbar-thin sticky top-0 h-svh min-w-60 !overflow-y-auto truncate bg-background pt-5">
           {menu.map(item => {

--- a/src/components/shared/content-sidebar.tsx
+++ b/src/components/shared/content-sidebar.tsx
@@ -19,7 +19,7 @@ type Props = {
 
 export function ContentSidebar({ menu, children }: Props) {
   return (
-    <div className="container mx-auto flex min-h-svh !w-full divide-x-4">
+    <div className="container mx-auto flex min-h-svh !w-full divide-x-2">
       <div className="scrollbar-thin sticky top-0 h-svh min-w-60 !overflow-y-auto truncate bg-background pt-5">
         {menu.map(item => {
           return (

--- a/src/components/shared/index.ts
+++ b/src/components/shared/index.ts
@@ -5,4 +5,3 @@ export * from './noice';
 export * from './scattered-dots';
 export * from './theme-provider';
 export * from './user-image';
-

--- a/src/components/ui/shadcn/card.tsx
+++ b/src/components/ui/shadcn/card.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import * as React from 'react';
 
-import { cn } from "@/utils"
+import { cn } from '@/utils';
 
 const Card = React.forwardRef<
   HTMLDivElement,
@@ -9,13 +9,13 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      'rounded-xl border bg-card text-card-foreground shadow',
       className
     )}
     {...props}
   />
-))
-Card.displayName = "Card"
+));
+Card.displayName = 'Card';
 
 const CardHeader = React.forwardRef<
   HTMLDivElement,
@@ -23,11 +23,11 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn('flex flex-col space-y-1.5 p-6', className)}
     {...props}
   />
-))
-CardHeader.displayName = "CardHeader"
+));
+CardHeader.displayName = 'CardHeader';
 
 const CardTitle = React.forwardRef<
   HTMLDivElement,
@@ -35,11 +35,11 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("font-semibold leading-none tracking-tight", className)}
+    className={cn('font-semibold leading-none tracking-tight', className)}
     {...props}
   />
-))
-CardTitle.displayName = "CardTitle"
+));
+CardTitle.displayName = 'CardTitle';
 
 const CardDescription = React.forwardRef<
   HTMLDivElement,
@@ -47,19 +47,19 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn('text-sm text-muted-foreground', className)}
     {...props}
   />
-))
-CardDescription.displayName = "CardDescription"
+));
+CardDescription.displayName = 'CardDescription';
 
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
-))
-CardContent.displayName = "CardContent"
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+));
+CardContent.displayName = 'CardContent';
 
 const CardFooter = React.forwardRef<
   HTMLDivElement,
@@ -67,10 +67,17 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn('flex items-center p-6 pt-0', className)}
     {...props}
   />
-))
-CardFooter.displayName = "CardFooter"
+));
+CardFooter.displayName = 'CardFooter';
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent }
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+  CardContent
+};


### PR DESCRIPTION
This pull request includes changes to improve the URL structure and adjust the layout styling in the project. The most important changes include modifying the way slugs are resolved and updating the layout styling for the sidebar components.

### URL Structure Improvements:
* [`contentlayer.config.js`](diffhunk://#diff-bb0868a752a3d350fd9850681e484b22d3ee514582608da216644abdca2886a4L21-R21): Changed the `slug` resolution to join all parts of the flattened path without slicing.
* `src/app/[categoryId]/[...slug]/page.tsx`: Updated the `Page` function to include `categoryId` in the slug construction, ensuring the correct URL structure. ([src/app/[categoryId]/[...slug]/page.tsxL11-R13](diffhunk://#diff-169f18f0ea05934130fce8153751b78878125b3e5f4d3c49c2460b0796306305L11-R13))

### Layout Styling Adjustments:
* `src/app/[categoryId]/sidebar.tsx`: Modified the `ContentSidebar` component to use a thinner divide line (`divide-x-2` instead of `divide-x-4`). ([src/app/[categoryId]/sidebar.tsxL28-R28](diffhunk://#diff-c8d6ac068ec710a368a7484724d6a8e3339264f8dd442374f7f80879a85b516bL28-R28))
* [`src/components/shared/content-sidebar.tsx`](diffhunk://#diff-1a7ffa1fb550cb0c9d9f511d2043b54f9ddb324474fe73780363de3d665ef88eL22-R22): Similarly updated the `ContentSidebar` component to use a thinner divide line (`divide-x-2` instead of `divide-x-4`).